### PR TITLE
skip when no navigator (fixes #2)

### DIFF
--- a/web-locks-polyfill.js
+++ b/web-locks-polyfill.js
@@ -1,6 +1,6 @@
 import makeLocksRequest from "./make-locks-request.js";
 
-if(!navigator.locks) {
+if(typeof navigator !== "undefined" && !navigator.locks) {
   navigator.locks = {
     request: makeLocksRequest({storage: localStorage, memorySafe: false}),
     get query(){


### PR DESCRIPTION
This causes the polyfill to no-op when `navigator` is undefined. This can happen in SSR and other non-browser environments. Without this fix, these environments couldn't even include projects with this as a dependency. This will not make it function in those but will allow the polyfill to be included.